### PR TITLE
Hotfix: SDS Parameter Fix

### DIFF
--- a/podaac/swodlr_ingest_to_sds/submit_to_sds.py
+++ b/podaac/swodlr_ingest_to_sds/submit_to_sds.py
@@ -157,9 +157,8 @@ def _gen_mozart_job_params(filename, url):
             'restaged': False,
             'ISL_urls': url
         },
-        'create_hash': 'true',  # Why is this a string?
-        'hash_type': 'md5',
-        'update_s3_tag': False
+        'create_hash': 'false',   # Why is this a string?
+        'update_s3_tag': 'false'  # Why is this a string?
     }
 
     return params


### PR DESCRIPTION
Switches `create_hash` to `"false"` (boolean as a string).